### PR TITLE
Adjusted isSnowyEnough for inclusivity

### DIFF
--- a/SnowWatch.js
+++ b/SnowWatch.js
@@ -47,10 +47,12 @@ SnowWatch.prototype.isSnowyEnough = function(forecast) {
     + ", minProb=" + this.precipProbabilityMin
     + ", enough? " + (forecast.precipProbability >= this.precipProbabilityMin));
   return (
-        forecast.precipType == 'snow' 
-      ||  forecast.precipType == 'sleet'
+    (
+      (forecast.precipType == 'snow' || forecast.precipType == 'sleet')
+      || forecast.temperature <= 34
     )
-    && forecast.precipProbability >= this.precipProbabilityMin;
+    && forecast.precipProbability >= this.precipProbabilityMin
+  );
 }
 
 SnowWatch.prototype.lastSnowPrediction = function() {


### PR DESCRIPTION
The Dark Sky API occasionally categorizes sub-freezing precipitation as neither snow nor sleet, thus not tripping the sensor despite snowy conditions. I adjusted `isSnowyEnough` to additionally return true if `forecast.temperature` is below 34° (approx. range) and `forecast.precipProbability` is inclusive.

In my testing, precipitation below 34° is snow-like and should trip its sensor, as it causes ice and snow buildup.