### PR TITLE
Fix release workflow to use RELEASE_TOKEN for protected branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fix the release workflow to use `RELEASE_TOKEN` (PAT) instead of `GITHUB_TOKEN` for pushing to the protected main branch.

The default `GITHUB_TOKEN` cannot bypass branch protection rules, even with admin override settings.

## Changes

- Updated checkout step to use `secrets.RELEASE_TOKEN` instead of `secrets.GITHUB_TOKEN`

## Test plan

- [ ] Merge this PR
- [ ] Run release workflow with dry_run=true to verify push works
- [ ] Run actual release

🤖 Generated with [Claude Code](https://claude.com/claude-code)